### PR TITLE
Hashable DeviceId

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ impl Device {
 }
 
 /// An opaque struct that wraps the OS specific identifier of a device
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Hash, Clone, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct DeviceId(BackendDeviceId);
 


### PR DESCRIPTION
Implements Hash for DeviceId.

As mentioned in #3, all underlying platform-specific types used by DeviceId already implement Hash except windows-rs HSTRING.  This PR utilizes the recent addition of HSTRING Hash impl to windows-rs ([the windows-rs commit](https://github.com/microsoft/windows-rs/commit/6f4a72668cd8678bca9dca0311b47574725e902b)).  Due to utilizing a more recent windows-rs version with API changes, additional changes were made to async-hid to satisfy those changes.

As of writing, the commit has been merged into windows-rs master ([the PR](https://github.com/microsoft/windows-rs/pull/2924), but a new release has not been released yet (will be version 0.56.0).  Will update this PR when windows-rs releases a change.

Resolves #3 