### PR TITLE
Hashable deviceinfo (and modifications to Eq and PartialEq impl)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod error;
 
 use std::fmt::{Debug, Formatter};
 use std::future::Future;
+use std::hash::{Hash, Hasher};
 
 use futures_core::Stream;
 
@@ -14,7 +15,7 @@ pub use crate::error::{ErrorSource, HidError, HidResult};
 /// A struct containing basic information about a device
 ///
 /// This struct can be obtained by calling [DeviceInfo::enumerate] and upgraded into a usable [Device] by calling [DeviceInfo::open].
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct DeviceInfo {
     /// OS specific identifier
     pub id: DeviceId,
@@ -29,8 +30,32 @@ pub struct DeviceInfo {
     /// The HID usage page
     pub usage_page: u16,
 
-    pub(crate) private_data: BackendPrivateData
+    pub(crate) private_data: BackendPrivateData,
 }
+
+impl Hash for DeviceInfo {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.name.hash(state);
+        self.product_id.hash(state);
+        self.vendor_id.hash(state);
+        self.usage_id.hash(state);
+        self.usage_page.hash(state);
+    }
+}
+
+impl PartialEq for DeviceInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+            && self.name == other.name
+            && self.product_id == other.product_id
+            && self.vendor_id == other.vendor_id
+            && self.usage_id == other.usage_id
+            && self.usage_page == other.usage_page
+    }
+}
+
+impl Eq for DeviceInfo {}
 
 impl DeviceInfo {
     /// Enumerates all **accessible** HID devices

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,30 +33,6 @@ pub struct DeviceInfo {
     pub(crate) private_data: BackendPrivateData,
 }
 
-impl Hash for DeviceInfo {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
-        self.name.hash(state);
-        self.product_id.hash(state);
-        self.vendor_id.hash(state);
-        self.usage_id.hash(state);
-        self.usage_page.hash(state);
-    }
-}
-
-impl PartialEq for DeviceInfo {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
-            && self.name == other.name
-            && self.product_id == other.product_id
-            && self.vendor_id == other.vendor_id
-            && self.usage_id == other.usage_id
-            && self.usage_page == other.usage_page
-    }
-}
-
-impl Eq for DeviceInfo {}
-
 impl DeviceInfo {
     /// Enumerates all **accessible** HID devices
     ///
@@ -81,6 +57,30 @@ impl DeviceInfo {
         self.usage_page == usage_page && self.usage_id == usage_id && self.vendor_id == vendor_id && self.product_id == product_id
     }
 }
+
+impl Hash for DeviceInfo {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.name.hash(state);
+        self.product_id.hash(state);
+        self.vendor_id.hash(state);
+        self.usage_id.hash(state);
+        self.usage_page.hash(state);
+    }
+}
+
+impl PartialEq for DeviceInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+            && self.name == other.name
+            && self.product_id == other.product_id
+            && self.vendor_id == other.vendor_id
+            && self.usage_id == other.usage_id
+            && self.usage_page == other.usage_page
+    }
+}
+
+impl Eq for DeviceInfo {}
 
 pub trait SerialNumberExt {
     fn serial_number(&self) -> Option<&str>;


### PR DESCRIPTION
Implemented Hash, Eq, and PartialEq as described in conversation of issue #5 such that all fields except `private_data` are compared against.

PR dependent on PR #4 
Resolves #5 