### PR TITLE
Fix: the trait bound `RegistryEntryId: Hash` is not satisfied

### DIFF
--- a/src/backend/iohidmanager/service.rs
+++ b/src/backend/iohidmanager/service.rs
@@ -61,7 +61,7 @@ impl Drop for IOService {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[repr(transparent)]
 pub struct RegistryEntryId(u64);
 


### PR DESCRIPTION
I encountered the following error compiling the main branch for target aarch64-apple-darwin. Maybe you just missed to test macOS after a modification... Pull request adds Hash for derive.

```
error[E0277]: the trait bound `RegistryEntryId: Hash` is not satisfied
   --> async-hid/src/lib.rs:120:21
    |
118 | #[derive(Hash, Clone, Eq, PartialEq)]
    |          ---- in this derive macro expansion
119 | #[repr(transparent)]
120 | pub struct DeviceId(BackendDeviceId);
    |                     ^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `RegistryEntryId`
    |
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider annotating `RegistryEntryId` with `#[derive(Hash)]`
   --> async-hid/src/backend/iohidmanager/service.rs:66:1
    |
66  + #[derive(Hash)]
67  | pub struct RegistryEntryId(u64);
    |

```