### PR TITLE
Allow device to be shared among threads for macOS backend.

### DIFF
--- a/src/backend/iohidmanager/device.rs
+++ b/src/backend/iohidmanager/device.rs
@@ -1,5 +1,5 @@
 use std::ffi::c_void;
-use std::mem::{ManuallyDrop};
+use std::mem::ManuallyDrop;
 use std::ptr::null_mut;
 use std::slice::from_raw_parts;
 


### PR DESCRIPTION
This patch ensures that the backend implements Sync, as is already the case with Linux and Windows.

This has not worked so far because ‘Box’ was saved in the backend, which must not be shared between threads in the secure Rust context. Since the data is only provided for the callback that is called from C, I decided to save only the raw pointer/data as usize and to free manually in Drop.

This also guarantees that nobody accesses the data in parallel to the callback during operation.

Tested successfully on a Mac Studio M1 Max.