### PR TITLE
Improve Netlink socket to avoid race conditions on Linux

### DIFF
--- a/examples/watch_devices.rs
+++ b/examples/watch_devices.rs
@@ -19,8 +19,8 @@ async fn main() -> HidResult<()> {
         .await;
 
     loop {
-        print_device_set(&device_set);
-        //println!("Number of connected devices: {}", device_set.len());
+        //print_device_set(&device_set);
+        println!("Number of connected devices: {}", device_set.len());
         if let Some(event) = watcher.next().await {
             //println!("Event: {:?}", event);
             match event {

--- a/src/backend/hidraw/mod.rs
+++ b/src/backend/hidraw/mod.rs
@@ -54,7 +54,7 @@ impl Backend for HidRawBackend {
             Ok(_) => {
                 trace!("Udev deamon seems to be running, binding to udev monitor group");
                 MONITOR_GROUP_UDEV
-            },
+            }
             Err(err) => {
                 trace!("Udev deamon seems not to be running ({:?}), binding to kernel monitor group", err);
                 MONITOR_GROUP_KERNEL

--- a/src/backend/hidraw/mod.rs
+++ b/src/backend/hidraw/mod.rs
@@ -7,7 +7,6 @@ use std::io::ErrorKind;
 use std::os::fd::{AsRawFd, OwnedFd};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Component, Path, PathBuf};
-use std::process;
 use std::sync::Arc;
 
 use futures_lite::stream::{iter, unfold, Boxed};
@@ -52,7 +51,7 @@ impl Backend for HidRawBackend {
             SockFlag::SOCK_CLOEXEC | SockFlag::SOCK_NONBLOCK,
             SockProtocol::NetlinkKObjectUEvent
         )?;
-        bind(socket.as_raw_fd(), &NetlinkAddr::new(process::id(), MONITOR_GROUP_UDEV))?;
+        bind(socket.as_raw_fd(), &NetlinkAddr::new(0, MONITOR_GROUP_UDEV))?;
 
         Ok(unfold((AsyncFd::new(socket)?, vec![0u8; 4096]), |(socket, mut buf)| async move {
             loop {

--- a/src/backend/hidraw/uevent.rs
+++ b/src/backend/hidraw/uevent.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+
 use crate::ensure;
 
 #[derive(Debug)]
@@ -22,20 +23,24 @@ impl<'a> UEvent<'a> {
             const UDEV_MONITOR_MAGIC: u32 = 0xfeedcafe;
             let magic = u32::from_be_bytes(event[8..12].try_into().unwrap());
             ensure!(magic == UDEV_MONITOR_MAGIC, "Invalid magic number");
-            
+
             u32::from_ne_bytes(event[16..20].try_into().unwrap()) as usize
         } else {
             ensure!(event.contains(&b'@'), "Invalid kernel event");
-            event.iter().position(|&b| b == b'\0').ok_or("Failed to find the start of the message")? + 1
+            event
+                .iter()
+                .position(|&b| b == b'\0')
+                .ok_or("Failed to find the start of the message")?
+                + 1
         };
-        
+
         Self::parse_internal(&event[offset..])
     }
     fn parse_internal(event: &'a [u8]) -> Result<UEvent<'a>, &'static str> {
         let mut action = None;
         let mut subsystem = None;
         let mut dev_path = None;
-        
+
         for line in std::str::from_utf8(event)
             .map_err(|_| "Invalid utf-8")?
             .split('\0')


### PR DESCRIPTION
The HIDRAW backend currectly directly watches for device events from the kernel. This can cause race conditions between the udev deamon and this library. We should instead watch for messages emitted from udev itself, if available.

Fixes #27 