### PR TITLE
feat: read_feature_report

### DIFF
--- a/src/backend/hidraw/mod.rs
+++ b/src/backend/hidraw/mod.rs
@@ -145,6 +145,10 @@ impl Backend for HidRawBackend {
 
         Ok((read.then(|| device.clone()), write.then(|| device.clone())))
     }
+
+    async fn read_feature_report(&self, id: &DeviceId, buf: &mut [u8]) -> HidResult<usize> {
+        Err(HidError::message("Not implemented"))
+    }
 }
 
 fn get_device_info_raw(path: PathBuf) -> HidResult<Vec<DeviceInfo>> {

--- a/src/backend/iohidmanager/mod.rs
+++ b/src/backend/iohidmanager/mod.rs
@@ -128,6 +128,10 @@ impl Backend for IoHidManagerBackend {
         let rw = Arc::new(DeviceReadWriter::new(device, read, write)?);
         Ok((read.then_some(rw.clone()), write.then_some(rw)))
     }
+
+    async fn read_feature_report(&self, id: &DeviceId, buf: &mut [u8]) -> HidResult<usize> {
+        Err(HidError::message("Not implemented"))
+    }
 }
 
 fn get_device(id: &DeviceId, dispatch_queue: Option<&DispatchQueue>) -> HidResult<CFRetained<IOHIDDevice>> {

--- a/src/device_info.rs
+++ b/src/device_info.rs
@@ -172,4 +172,9 @@ impl Device {
         let (r, w) = self.backend.open(&self.id, true, true).await?;
         Ok((DeviceReader(r.unwrap()), DeviceWriter(w.unwrap())))
     }
+
+    /// Read a feature report from the device
+    pub async fn read_feature_report(&self, buf: &mut [u8]) -> HidResult<usize> {
+        self.backend.read_feature_report(&self.id, buf).await
+    }
 }


### PR DESCRIPTION
This PR enables the use of read_feature_report in the `WinRT` and `Win32` backends.

For the `hidraw` and `iohidmanager` backends, it currently returns an error message stating that it's not implemented yet.

I decided to implement this method as part of the `Backend` trait and `Device` struct, instead of creating a new `AsyncHidFeatureRead` trait and an `open_feature` method in the `Backend` trait, because most feature reports are one-shot operations rather than streams of data (like input reports). This makes it easier for downstream code to use, since there's no need to first open a feature-readable stream and then read from it.