### PR TITLE
Fix panic on Win32 when device does not support feature reports

### DIFF
--- a/src/backend/win32/mod.rs
+++ b/src/backend/win32/mod.rs
@@ -22,7 +22,7 @@ use crate::backend::{Backend, DeviceInfoStream};
 use crate::device_info::DeviceId;
 use crate::error::HidResult;
 use crate::traits::{AsyncHidFeatureHandle, AsyncHidRead, AsyncHidWrite};
-use crate::{DeviceEvent, DeviceInfo, HidError};
+use crate::{ensure, DeviceEvent, DeviceInfo, HidError};
 
 #[derive(Default)]
 pub struct Win32Backend;
@@ -80,6 +80,11 @@ impl Backend for Win32Backend {
 
         let device = Arc::new(Device::open(id, false, false)?);
         let caps = device.preparsed_data()?.caps()?;
+
+        ensure!(
+            caps.FeatureReportByteLength > 0,
+            HidError::message("Device does not support feature reports")
+        );
 
         let feature_buffer = IoBuffer::<Feature>::new(device, caps.FeatureReportByteLength as usize)?;
         Ok(feature_buffer)


### PR DESCRIPTION
When trying to read feature reports from device that has `FeatureReportByteLength == 0`, Win32 backend panics:

```
thread 'main' (11692) panicked at /home/lynx/projects/async-hid/src/backend/win32/buffer.rs:209:9:
index out of bounds: the len is 0 but the index is 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Added a check for `FeatureReportByteLength` to be > 0

Tested on Windows 11 LTSC VM